### PR TITLE
Hide footer when no action is passed to s-modal

### DIFF
--- a/addon/components/s-modal.js
+++ b/addon/components/s-modal.js
@@ -8,7 +8,7 @@ export default Component.extend({
   layout,
   classNames: ['s-modal'],
   isVisible: true,
-  actionPassed: computed('onCancel', 'onOK', function(){
+  showFooter: computed('onCancel', 'onOK', function(){
     if (this.get('onCancel') || this.get('onOK')) {
       return true;
     }

--- a/addon/components/s-modal.js
+++ b/addon/components/s-modal.js
@@ -1,8 +1,18 @@
 import Component from '@ember/component';
 import layout from '../templates/components/s-modal';
+import {
+  computed
+} from '@ember/object';
 
 export default Component.extend({
-    layout,
-    classNames: ['s-modal']
+  layout,
+  classNames: ['s-modal'],
+  actionPassed: computed('onCancel', 'onOK', function(){
+    if(this.get('onCancel') || this.get('onOK')){
+      return true;
+    }
+    return false;
+  })
+
 
 });

--- a/addon/templates/components/s-modal.hbs
+++ b/addon/templates/components/s-modal.hbs
@@ -12,36 +12,40 @@
       {{#if header}}
         <div class="modal-header">
           <h5 class="modal-title" id="exampleModalLabel">{{header}}</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
+          {{#if onCancel}}
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close" {{action onCancel}}>
+              <span aria-hidden="true">&times;</span>
+            </button>
+          {{/if}}
         </div>
       {{/if}}
       <div  class="modal-body">
         {{yield}}
       </div>
-      <div class="modal-footer">
-        {{#if onCancel }}
-          {{#s-button
-            onClick=(action onCancel)
-            cssClasses="float-left"
-            color= "secondary"
-            data-dismiss="modal"
-          }}
-            {{cancelText}}
-          {{/s-button}}
-        {{/if}}
-        {{#if onOK }}
-          {{#s-button
-            color="primary"
-            cssClasses="float-left"
-            data-dismiss="modal"
-            onClick=(action onOK)
-          }}
-            {{okText}}
-          {{/s-button}}
-        {{/if}}
+      {{#if actionPassed}}
+        <div class="modal-footer">
+          {{#if onCancel }}
+            {{#s-button
+              onClick=(action onCancel)
+              cssClasses="float-left"
+              color= "secondary"
+              data-dismiss="modal"
+            }}
+              {{cancelText}}
+            {{/s-button}}
+          {{/if}}
+          {{#if onOK }}
+            {{#s-button
+              color="primary"
+              cssClasses="float-left"
+              data-dismiss="modal"
+              onClick=(action onOK)
+            }}
+              {{okText}}
+            {{/s-button}}
+          {{/if}}
         </div>
+      {{/if}}
     </div>
   </div>
 </div>

--- a/addon/templates/components/s-modal.hbs
+++ b/addon/templates/components/s-modal.hbs
@@ -23,7 +23,7 @@
       <div class="modal-body">
         {{yield}}
       </div>
-      {{#if actionPassed}}
+      {{#if showFooter}}
         <div class="modal-footer">
           {{#if onCancel}}
             {{#s-button


### PR DESCRIPTION
There can be a case where the user wants to provide custom actions and add custom buttons to the modal. In such cases we do not want to show the footer.